### PR TITLE
Fixed base model in a Forge blockstates loader json not applying its rotation.

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -176,7 +176,6 @@ public class BlockStateLoader
             // If baseRot is non-null, then that rotation will be applied instead of the base model's rotation.
             // This is used to allow replacing base model with a submodel when there is no base model for a variant.
             ModelRotation baseRot = getRotation();
-            baseRot = getRotation();
             ImmutableMap.Builder<String, Pair<IModel, IModelState>> models = ImmutableMap.builder();
             for (Entry<String, SubModel> entry : parts.entrySet())
             {
@@ -190,7 +189,7 @@ public class BlockStateLoader
                 models.put(entry.getKey(), Pair.of(runModelHooks(loader.getModel(part.getModelLocation()), part.getTextures(), part.getCustomData()), partState));
             }
 
-            return new MultiModel(hasBase ? base : null, models.build());
+            return new MultiModel(hasBase ? base : null, baseRot, models.build());
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -134,17 +134,19 @@ public class MultiModel implements IModel
     }
     
     protected final IModel base;
+    protected final IModelState baseState;
     protected final Map<String, Pair<IModel, IModelState>> parts;
     
-    public MultiModel(IModel base, ImmutableMap<String, Pair<IModel, IModelState>> parts)
+    public MultiModel(IModel base, IModelState baseState, ImmutableMap<String, Pair<IModel, IModelState>> parts)
     {
         this.base = base;
+        this.baseState = baseState;
         this.parts = parts;
     }
 
-    public MultiModel(IModel base, Map<String, Pair<IModel, IModelState>> parts)
+    public MultiModel(IModel base, IModelState baseState, Map<String, Pair<IModel, IModelState>> parts)
     {
-        this(base, ImmutableMap.copyOf(parts));
+        this(base, baseState, ImmutableMap.copyOf(parts));
     }
     
     @Override
@@ -176,12 +178,12 @@ public class MultiModel implements IModel
     }
     
     @Override
-    public IFlexibleBakedModel bake(final IModelState state, VertexFormat format, Function<ResourceLocation, TextureAtlasSprite> bakedTextureGetter)
+    public IFlexibleBakedModel bake(IModelState state, VertexFormat format, Function<ResourceLocation, TextureAtlasSprite> bakedTextureGetter)
     {
         IFlexibleBakedModel bakedBase = null;
         
         if (base != null)
-            bakedBase = base.bake(state, format, bakedTextureGetter);
+            bakedBase = base.bake(baseState, format, bakedTextureGetter);
         
         ImmutableMap.Builder<String, IFlexibleBakedModel> mapBuilder = ImmutableMap.builder();
         


### PR DESCRIPTION
Fixed the base model of a json not being rotated according to its Variant's rotation values.